### PR TITLE
Revert "Remove unnecessary RBAC permissions"

### DIFF
--- a/assets/rbac/csi_driver_binding.yaml
+++ b/assets/rbac/csi_driver_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: azure-file-csi-driver-binding
+subjects:
+  - kind: ServiceAccount
+    name: azure-file-csi-driver-controller-sa
+    namespace: openshift-cluster-csi-drivers
+roleRef:
+  kind: ClusterRole
+  name: azure-file-csi-driver-role
+  apiGroup: rbac.authorization.k8s.io

--- a/assets/rbac/csi_driver_role.yaml
+++ b/assets/rbac/csi_driver_role.yaml
@@ -1,0 +1,8 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: azure-file-csi-driver-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -77,6 +77,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"node_sa.yaml",
 			"csidriver.yaml",
 			"service.yaml",
+			"rbac/csi_driver_role.yaml",
+			"rbac/csi_driver_binding.yaml",
 			"rbac/attacher_role.yaml",
 			"rbac/attacher_binding.yaml",
 			"rbac/privileged_role.yaml",


### PR DESCRIPTION
This reverts commit 3360477e25458b9c5a44f11cde8fcd82ea31aa67.

CSI driver deals with secrets as well.

/hold
for manual testing.
