### PR TITLE
Bug 2019128: Temporarily disable snapshot tests + add manifest for NFS

### DIFF
--- a/test/e2e/manifest-nfs.yaml
+++ b/test/e2e/manifest-nfs.yaml
@@ -1,0 +1,19 @@
+# Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+ShortName: azurefile-nfs
+StorageClass:
+  FromName: true
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: file.csi.azure.com
+  Capabilities:
+    persistence: true
+    exec: true
+    multipods: true
+    RWX: true
+    fsGroup: false
+    topology: false
+    controllerExpansion: true
+    nodeExpansion: true
+    volumeLimits: false
+    snapshotDataSource: true

--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -11,9 +11,11 @@ DriverInfo:
     exec: true
     multipods: true
     RWX: true
+    # TODO: Re-enable fsGroup tests: https://bugzilla.redhat.com/show_bug.cgi?id=2019128
     fsGroup: false
     topology: false
     controllerExpansion: true
     nodeExpansion: true
     volumeLimits: false
-    snapshotDataSource: true
+    # TODO: Re-enable snapshot tests: https://bugzilla.redhat.com/show_bug.cgi?id=2019128
+    snapshotDataSource: false


### PR DESCRIPTION
This PR adds an additional manifest file to support a new e2e job for testing the NFS backend.

The CSI driver supports NFS 4.1 as "Public Preview", so we want a job to test that and make sure it works as expected in OCP.

In addition to this manifest, this PR has a commit to temporarily disable snapshot tests until[ this bug](https://bugzilla.redhat.com/show_bug.cgi?id=2019128) is solved. The idea is to make the job non-optional [here](https://github.com/openshift/release/pull/23165) to catch other potential flakes.

CC @openshift/storage