### PR TITLE
Bug 2019128: Re-enable snapshot and fsGroup tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -11,11 +11,9 @@ DriverInfo:
     exec: true
     multipods: true
     RWX: true
-    # TODO: Re-enable fsGroup tests: https://bugzilla.redhat.com/show_bug.cgi?id=2019128
-    fsGroup: false
+    fsGroup: true
     topology: false
     controllerExpansion: true
     nodeExpansion: true
     volumeLimits: false
-    # TODO: Re-enable snapshot tests: https://bugzilla.redhat.com/show_bug.cgi?id=2019128
-    snapshotDataSource: false
+    snapshotDataSource: true


### PR DESCRIPTION
This is a placeholder PR to enable the snapshot and fsGroup tests once they are fixed.

CC @openshift/storage
