### PR TITLE
Bug 2042960: Remove UID, GID from StorageClass asset

### DIFF
--- a/assets/storageclass.yaml
+++ b/assets/storageclass.yaml
@@ -12,8 +12,6 @@ volumeBindingMode: Immediate
 mountOptions:
   - dir_mode=0777
   - file_mode=0777
-  - uid=0
-  - gid=0
   - mfsymlinks
   - cache=strict  # https://linux.die.net/man/8/mount.cifs
   - nosharesock  # reduce probability of reconnect race


### PR DESCRIPTION
The tests using the StorageClass asset fail because of the GID mismatch with pod's. This was actually updated upstream too: https://github.com/kubernetes-sigs/azurefile-csi-driver/commit/451d5776b17791de2a7c2640d4dcfab2f658ecd0