### PR TITLE
Fix driver definition manifest: fsGroup is supported, snapshots are not

### DIFF
--- a/test/e2e/manifest-nfs.yaml
+++ b/test/e2e/manifest-nfs.yaml
@@ -11,7 +11,8 @@ DriverInfo:
     exec: true
     multipods: true
     RWX: true
-    fsGroup: false
+    fsGroup: true
+    volumeMountGroup: true
     topology: false
     controllerExpansion: true
     nodeExpansion: true

--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -11,11 +11,11 @@ DriverInfo:
     exec: true
     multipods: true
     RWX: true
-    # TODO: Re-enable fsGroup tests: https://bugzilla.redhat.com/show_bug.cgi?id=2019128
-    fsGroup: false
+    fsGroup: true
+    volumeMountGroup: true
     topology: false
     controllerExpansion: true
     nodeExpansion: true
     volumeLimits: false
-    # TODO: Re-enable snapshot tests: https://bugzilla.redhat.com/show_bug.cgi?id=2019128
+    # Snapshots are not supported in this release
     snapshotDataSource: false


### PR DESCRIPTION
CC @openshift/storage
