### PR TITLE
Bug 2092502: Don't ship a StorageClass backed by NFS by default

### DIFF
--- a/assets/storageclass.yaml
+++ b/assets/storageclass.yaml
@@ -10,8 +10,6 @@ parameters:
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 mountOptions:
-  - dir_mode=0777
-  - file_mode=0777
   - mfsymlinks
   - cache=strict  # https://linux.die.net/man/8/mount.cifs
   - nosharesock  # reduce probability of reconnect race

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -73,7 +73,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		assets.ReadFile,
 		[]string{
 			"storageclass.yaml",
-			"storageclass_nfs.yaml",
 			"controller_sa.yaml",
 			"controller_pdb.yaml",
 			"node_sa.yaml",

--- a/test/e2e/manifest-nfs.yaml
+++ b/test/e2e/manifest-nfs.yaml
@@ -1,7 +1,7 @@
 # Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
 ShortName: azurefile-nfs
 StorageClass:
-  FromExistingClassName: azurefile-csi-nfs
+  FromName: true
 SnapshotClass:
   FromName: true
 DriverInfo:


### PR DESCRIPTION
Users may still create it manually if they want to use NFS with Azure File.

Additionally, remove _dir_mode_ and _file_mode_ mount options from SC.

CC @openshift/storage  