### PR TITLE
Bug 2080449: disable VHD disk feature

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -71,6 +71,7 @@ spec:
           image: ${DRIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - --enable-vhd=false
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --metrics-address=localhost:8211


### PR DESCRIPTION
Azure file driver now allows VHD disk feature [opt-out](https://github.com/openshift/azure-file-csi-driver/pull/15) - need to add the new flag to the controller deployment.