### PR TITLE
STOR-1078: Add hostPaths necessary for SELinux mounts

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -95,6 +95,10 @@ spec:
               name: sys-devices-dir
             - mountPath: /sys/class/scsi_host/
               name: scsi-host-dir
+            - name: etc-selinux
+              mountPath: /etc/selinux
+            - name: sys-fs
+              mountPath: /sys/fs
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node and cannot
@@ -189,3 +193,11 @@ spec:
           name: scsi-host-dir
         - name: merged-cloud-config
           emptydir:
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs
+            type: Directory


### PR DESCRIPTION
To support "mount -o context=XYZ", /etc/selinux and /sys/fs/selinux from the host must be present in the CSI driver container.

cc @openshift/storage 