### PR TITLE
STOR-1127: Set the CSI StorageClass as the default one on new installations

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -72,7 +72,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeInformersForNamespaces,
 		assets.ReadFile,
 		[]string{
-			"storageclass.yaml",
 			"controller_sa.yaml",
 			"controller_pdb.yaml",
 			"node_sa.yaml",
@@ -140,6 +139,12 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		dynamicClient,
 		assets.ReadFile,
 		"servicemonitor.yaml",
+	).WithStorageClassController(
+		"AzureFileStorageClassController",
+		assets.ReadFile,
+		"storageclass.yaml",
+		kubeClient,
+		kubeInformersForNamespaces.InformersFor(""),
 	)
 
 	klog.Info("Starting the informers")


### PR DESCRIPTION
This depends on the kube 1.26 rebase: https://github.com/openshift/kubernetes/pull/1432