### PR TITLE
OCPBUGS-6658: Disable managed identity authentication

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -49,6 +49,8 @@ spec:
           args:
             - --cloud-config-file-path=/etc/cloud-config/cloud.conf
             - --output-file-path=/etc/merged-cloud-config/cloud.conf
+            # Force disable node's managed identity, azure-disk-credentials Secret should be used.
+            - --disable-identity-extension-auth
           env:
             - name: AZURE_CLIENT_ID
               valueFrom:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -35,6 +35,8 @@ spec:
           args:
             - --cloud-config-file-path=/etc/cloud-config/cloud.conf
             - --output-file-path=/etc/merged-cloud-config/cloud.conf
+            # Force disable node's managed identity, azure-disk-credentials Secret should be used.
+            - --disable-identity-extension-auth
           env:
             - name: AZURE_CLIENT_ID
               valueFrom:


### PR DESCRIPTION
Managed identity authentication has precedence over username+password from azure-disk-credentials Secret. Force disable it when merging cloud.conf json.

See https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/223 for what the new cmdline option does (it forces useManagedIdentityExtension: false in cloud.conf).

https://github.com/orgs/openshift/teams/storage