### PR TITLE
OCPBUGS-8683: Add management workloads annotations

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -19,6 +19,8 @@ spec:
     metadata:
       labels:
         app: azure-file-csi-driver-controller
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       serviceAccount: azure-file-csi-driver-controller-sa

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         app: azure-file-csi-driver-node
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       serviceAccount: azure-file-csi-driver-node-sa


### PR DESCRIPTION
To support the workload partitioning we need to add the required annotations (openshift/enhancements#703).