### PR TITLE
CCO-325: Mount serviceaccount token into csi-driver container

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -113,6 +113,9 @@ spec:
             - name: msi
               mountPath: /var/lib/waagent/ManagedIdentity-Settings
               readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
           resources:
             requests:
               memory: 50Mi
@@ -312,3 +315,9 @@ spec:
             secretName: azure-file-csi-driver-controller-metrics-serving-cert
         - name: merged-cloud-config
           emptydir:
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift


### PR DESCRIPTION
Mount the service account token into the csi-driver container to enable Azure workload identity tokens.