### PR TITLE
[release-4.13] OCPBUGS-16250: Add management workloads annotations

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -19,6 +19,8 @@ spec:
     metadata:
       labels:
         app: azure-file-csi-driver-controller
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       serviceAccount: azure-file-csi-driver-controller-sa

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         app: azure-file-csi-driver-node
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       serviceAccount: azure-file-csi-driver-node-sa


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/azure-file-csi-driver-operator/pull/49 , fix the OCPBUGS-16250.