### PR TITLE
simplify workload identity feature enablement

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -98,7 +97,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 
 	replacedAssets := &assetWithReplacement{}
 	replacedAssets.Replace("${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}", os.Getenv(ccmOperatorImageEnvName))
-	replaceWorkloadIdentityConfig(replacedAssets, featureGateAccessor, kubeClient)
+	replaceWorkloadIdentityConfig(replacedAssets, featureGateAccessor)
 
 	csiControllerSet := csicontrollerset.NewCSIControllerSet(
 		operatorClient,
@@ -226,34 +225,19 @@ func (r *assetWithReplacement) GetAssetFunc() func(name string) ([]byte, error) 
 	}
 }
 
-func replaceWorkloadIdentityConfig(assets *assetWithReplacement, fg featuregates.FeatureGateAccess, kubeClient *kubeclient.Clientset) error {
+func replaceWorkloadIdentityConfig(assets *assetWithReplacement, fg featuregates.FeatureGateAccess) error {
+	workloadIdentity := "false"
+
 	featureGates, err := fg.CurrentFeatureGates()
 	if err != nil {
 		return err
 	}
-	wiEnabled, err := isWorkloadIdentityEnabled(featureGates, kubeClient)
-	if err != nil {
-		return err
-	}
-	if wiEnabled {
-		assets.Replace("${ENABLE_AZURE_WORKLOAD_IDENTITY}", "true")
-	} else {
-		assets.Replace("${ENABLE_AZURE_WORKLOAD_IDENTITY}", "false")
-	}
-	return nil
-}
 
-func isWorkloadIdentityEnabled(featureGates featuregates.FeatureGate, kubeClient *kubeclient.Clientset) (bool, error) {
-	if !featureGates.Enabled(configv1.FeatureGateAzureWorkloadIdentity) {
-		return false, nil
+	if featureGates.Enabled(configv1.FeatureGateAzureWorkloadIdentity) {
+		workloadIdentity = "true"
 	}
-	secret, err := kubeClient.CoreV1().Secrets(defaultNamespace).Get(context.Background(), cloudCredSecretName, metav1.GetOptions{})
-	if err != nil {
-		return false, fmt.Errorf("could not get secret %s/%s: %v", defaultNamespace, cloudCredSecretName, err)
-	}
-	_, hasKey := secret.Data[tokenFileKey]
-	if !hasKey {
-		klog.Warningf("Workloads Identity feature will be disabled: feature gate is enabled, but secret %s/%s doesn't have the %q key.", defaultNamespace, cloudCredSecretName, tokenFileKey)
-	}
-	return hasKey, nil
+
+	assets.Replace("${ENABLE_AZURE_WORKLOAD_IDENTITY}", workloadIdentity)
+
+	return nil
 }


### PR DESCRIPTION
Injector is now [changed](https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/268) so it's safe to set --enable-azure-workload-identity to "true" even when some of the values are not present. In that case injector will try to revert to user+secret authentication and log a warning.

Setting --enable-azure-workload-identity to "false" will make injector always use user+secret ignoring any values for workload identity that might be present.