### PR TITLE
OCPBUGS-33038: add token audience for Azure File

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -11,6 +11,8 @@ spec:
   fsGroupPolicy: "None"
   attachRequired: false
   podInfoOnMount: true
+  tokenRequests:
+    - audience: api://AzureADTokenExchange
   volumeLifecycleModes:
     - Persistent
     - Ephemeral


### PR DESCRIPTION
This is basically a backport of https://github.com/openshift/csi-operator/pull/224 but for Azure File operator since csi-operator is used in 4.16 and onwards.

